### PR TITLE
Specify items of `path` and `include_path`

### DIFF
--- a/plc.json
+++ b/plc.json
@@ -8,10 +8,10 @@
     "libraries" : [
         {
             "name" : "iec61131std",
-            "path" : "path/to/lib/",
+            "path" : "lib/",
             "package" : "Copy",
             "include_path" : [
-                "files/to/include"
+                "include/*.st"
             ]
         }
     ]


### PR DESCRIPTION
Makes the automation of building oscat with GitHub Actions easier.